### PR TITLE
Update Nissan Juke generations: Add Wikipedia reference and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Nissan Juke
 
+This repository contains signal set configurations for the Nissan Juke, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Nissan Juke.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Nissan_Juke"
+
 generations:
   - name: "First Generation (F15)"
     start_year: 2011


### PR DESCRIPTION
- Added Wikipedia article as primary reference source
- Updated README.md with standard template documentation
- Verified generational data against Wikipedia article confirming:
  * First Generation (F15): 2011-2019 model years
  * Second Generation (F16): 2020-present model years
